### PR TITLE
Fixes missing descriptions on hardware Apple TV devices.

### DIFF
--- a/appletv-poc-web-app/templates/ItemDetail.tvml
+++ b/appletv-poc-web-app/templates/ItemDetail.tvml
@@ -38,9 +38,8 @@
       <stack>
         <title>${this.item.title}</title>
 
-        <description allowsZooming="true">
-          <![CDATA[${this.item.description}]]>
-        </description>
+        <description allowsZooming="true">${this.item.description}</description>
+
         <row>
           <buttonLockup class="playBtn" id="play-button">
             <text>Play Video</text>


### PR DESCRIPTION
Apparently the production 9.0 tvOS implementation doesn't play nice with CDATA-wrapped text.
