### PR TITLE
Set 'ph' analytics type to Showcase

### DIFF
--- a/jwplayer-appletv-web-app/js/analytics/TVOSAnalytics.js
+++ b/jwplayer-appletv-web-app/js/analytics/TVOSAnalytics.js
@@ -141,7 +141,7 @@ var TVOSAnalytics = (function () {
       parameters[PARAM_AD_BLOCK] = 0;
       parameters[PARAM_EMBED_ID] = _embedId;
       parameters[PARAM_RENDERING_MODE] = "";
-      parameters[PARAM_PLAYER_HOSTING] = 0;
+      parameters[PARAM_PLAYER_HOSTING] = 4;
       parameters[PARAM_PLAYER_SIZE] = "";
       parameters = Utils.extend(parameters, data);
 


### PR DESCRIPTION
Set the 'ph' analytics parameter to '4' to enable segmenting plays from AppleTV as Showcase.